### PR TITLE
add delete action to rackspace_monitoring_check

### DIFF
--- a/resources/check.rb
+++ b/resources/check.rb
@@ -1,4 +1,5 @@
-actions :create
+actions :create, :delete
+default_action :create
 
 attribute :label, kind_of: String, name_attribute: true
 attribute :type, kind_of: String


### PR DESCRIPTION
This attempts to abstract out the type -> filename mapping of enabled monitoring checks, which allows for a simple "delete" action to be added.

fixes #4
